### PR TITLE
Return HTTP response for use with notification events.

### DIFF
--- a/src/PlivoChannel.php
+++ b/src/PlivoChannel.php
@@ -57,5 +57,7 @@ class PlivoChannel
         if ($response['status'] !== 202) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
+
+        return $response;
     }
 }


### PR DESCRIPTION
Laravel's NotificationSent event has a ```response``` property. That property is assigned via the return value on the Channel's ```send``` method. 

In order for users to receive Plivo's HTTP response through the NotificationSent event, Plivo's response is now returned.