### PR TITLE
Add support for plivo's sms status reporting webhook functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Log in to your [Plivo dashboard](https://manage.plivo.com/dashboard/) and grab y
     'auth_token' => env('PLIVO_AUTH_TOKEN'),
     // Country code, area code and number without symbols or spaces
     'from_number' => env('PLIVO_FROM_NUMBER'),
+    // The url Plivo will request to notify about changing sms statuses
+    'webhook' => ''
 ],
 ```
 
@@ -88,8 +90,9 @@ public function routeNotificationForPlivo()
 
 ### Available methods
 
-* `content()` - (string), SMS notification body
+* `content()` - (string) SMS notification body
 * `from()` - (integer) Override default from number
+* `webhook()` - (string) Override the webhook in the [config file](#setting-up-your-plivo-service)
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/notifications": "5.3.*|5.4.*",
         "illuminate/support": "5.3.*|5.4.*",
         "illuminate/events": "5.3.*|5.4.*",
+        "illuminate/queue": "5.3.*|5.4.*",
         "plivo/plivo-php": "^1.1"
     },
     "require-dev": {

--- a/src/Plivo.php
+++ b/src/Plivo.php
@@ -15,6 +15,9 @@ class Plivo extends PlivoRestApi
     /** @var string */
     protected $from;
 
+    /** @var string */
+    protected $webhook;
+
     /**
      * Create a new Plivo RestAPI instance.
      *
@@ -26,6 +29,7 @@ class Plivo extends PlivoRestApi
         $this->auth_id = $config['auth_id'];
         $this->authToken = $config['auth_token'];
         $this->from = $config['from_number'];
+        $this->webhook = array_key_exists('webhook', $config) ? $config['webhook'] : '';
 
         parent::__construct($this->auth_id, $this->authToken);
     }
@@ -38,5 +42,15 @@ class Plivo extends PlivoRestApi
     public function from()
     {
         return $this->from;
+    }
+
+    /**
+     * The webhook url plivo will call when statuses change.
+     *
+     * @return string
+     */
+    public function webhook()
+    {
+        return $this->webhook;
     }
 }

--- a/src/PlivoChannel.php
+++ b/src/PlivoChannel.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Plivo;
 
-use NotificationChannels\Plivo\Exceptions\CouldNotSendNotification;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\Plivo\Exceptions\CouldNotSendNotification;
 
 class PlivoChannel
 {
@@ -60,7 +60,7 @@ class PlivoChannel
             'src' => $message->from ?: $this->from,
             'dst' => $to,
             'text' => trim($message->content),
-            'url' => $message->webhook ?: $this->webhook
+            'url' => $message->webhook ?: $this->webhook,
         ]);
 
         if ($response['status'] !== 202) {

--- a/src/PlivoChannel.php
+++ b/src/PlivoChannel.php
@@ -20,12 +20,20 @@ class PlivoChannel
     protected $from;
 
     /**
+     * The webhook url that plivo will send status change notifications to.
+     *
+     * @var string
+     */
+    protected $webhook;
+
+    /**
      * @return  void
      */
     public function __construct(Plivo $plivo)
     {
         $this->plivo = $plivo;
         $this->from = $this->plivo->from();
+        $this->webhook = $this->plivo->webhook();
     }
 
     /**
@@ -52,6 +60,7 @@ class PlivoChannel
             'src' => $message->from ?: $this->from,
             'dst' => $to,
             'text' => trim($message->content),
+            'url' => $message->webhook ?: $this->webhook
         ]);
 
         if ($response['status'] !== 202) {

--- a/src/PlivoMessage.php
+++ b/src/PlivoMessage.php
@@ -19,15 +19,22 @@ class PlivoMessage
     public $from;
 
     /**
+     * The webhook url plivo will call for status updates.
+     *
+     * @var string
+     */
+    public $webhook;
+
+    /**
      * Create a new message instance.
      *
      * @param  string $content
      *
      * @return static
      */
-    public static function create($content = '')
+    public static function create($content = '', $webhook = '')
     {
-        return new static($content);
+        return new static($content, $webhook);
     }
 
     /**
@@ -35,9 +42,11 @@ class PlivoMessage
      *
      * @param  string  $content
      */
-    public function __construct($content = '')
+    public function __construct($content = '', $webhook = '')
     {
         $this->content = $content;
+
+        $this->webhook = $webhook;
     }
 
     /**
@@ -64,6 +73,20 @@ class PlivoMessage
     public function from($from)
     {
         $this->from = $from;
+
+        return $this;
+    }
+
+    /**
+     * Set the webhook url plivo will call for status updates.
+     *
+     * @param  string  $webhook
+     *
+     * @return $this
+     */
+    public function webhook($webhook)
+    {
+        $this->webhook = $webhook;
 
         return $this;
     }

--- a/tests/PlivoChannelTest.php
+++ b/tests/PlivoChannelTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace NotificationChannels\Plivo\Test;
+
+use NotificationChannels\Plivo\PlivoChannel;
+use NotificationChannels\Plivo\PlivoMessage;
+use Mockery;
+
+class PlivoChannelTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Base configuration for the plivo service.
+     * @var array
+     */
+    protected $baseConfig = [
+        'auth_id' => 'UNIT_TEST_AUTH_ID',
+        'auth_token' => 'UNIT_TEST_AUTH_TOKEN',
+        'from_number' => '18885551111'
+    ];
+
+    /**
+     * The mocked notifiable instance.
+     *
+     * @var mixed
+     */
+    protected $notifiable;
+
+    public function setup()
+    {
+        parent::setup();
+
+        $this->notifiable = Mockery::mock('notifiable')
+            ->shouldReceive('routeNotificationFor')
+            ->with('plivo')
+            ->andReturn('18885552222')
+            ->getMock();
+    }
+
+    /** @test */
+    public function it_has_empty_webhook_if_missing_from_config()
+    {
+        $config = $this->config($withWebhook = false);
+
+        $plivo = $plivo = $plivo = $this->mockedPlivo($config, [
+            'src' => $config['from_number'],
+            'dst' => $this->notifiable->routeNotificationFor('plivo'),
+            'text' => 'Content',
+            'url' => ''
+        ]);
+
+        $notification = $this->notification(new PlivoMessage('Content'));
+
+        (new PlivoChannel($plivo))
+            ->send($this->notifiable, $notification);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function it_uses_default_webhook_in_config()
+    {
+        $config = $this->config($withwebhook = true);
+
+        $plivo = $plivo = $this->mockedPlivo($config, [
+            'src' => $config['from_number'],
+            'dst' => $this->notifiable->routeNotificationFor('plivo'),
+            'text' => 'Content',
+            'url' => 'https://defaultexample.com'
+        ]);
+
+        $notification = $this->notification(new PlivoMessage('Content'));
+
+        (new PlivoChannel($plivo))
+            ->send($this->notifiable, $notification);
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function it_prefers_message_webhook_over_default_webhook()
+    {
+        $config = $this->config($withwebhook = true);
+
+        $plivo = $this->mockedPlivo($config, [
+            'src' => $config['from_number'],
+            'dst' => $this->notifiable->routeNotificationFor('plivo'),
+            'text' => 'Content',
+            'url' => 'https://messagewebhook.com'
+        ]);
+
+        $notification = $this->notification(new PlivoMessage('Content', 'https://messagewebhook.com'));
+
+        (new PlivoChannel($plivo))
+            ->send($this->notifiable, $notification);
+
+        $this->assertTrue(true);
+    }
+
+    private function notification($withPlivoMessage)
+    {
+        return Mockery::mock('\Illuminate\Notifications\Notification')
+            ->shouldReceive('toPlivo')
+            ->andReturn($withPlivoMessage)
+            ->getMock();
+    }
+
+    private function config($withWebhook)
+    {
+        if ($withWebhook) {
+            return array_merge($this->baseConfig, ['webhook' => 'https://defaultexample.com']);
+        }
+
+        return $this->baseConfig;
+    }
+
+    private function mockedPlivo($config, array $arguments)
+    {
+        return Mockery::mock('\NotificationChannels\Plivo\Plivo', [$config])
+            ->shouldReceive('send_message')
+            ->once()
+            ->with($arguments)
+            ->andReturn(['status' => 202])
+            ->getMock()
+            ->makePartial();
+    }
+}

--- a/tests/PlivoChannelTest.php
+++ b/tests/PlivoChannelTest.php
@@ -2,9 +2,9 @@
 
 namespace NotificationChannels\Plivo\Test;
 
+use Mockery;
 use NotificationChannels\Plivo\PlivoChannel;
 use NotificationChannels\Plivo\PlivoMessage;
-use Mockery;
 
 class PlivoChannelTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,7 +15,7 @@ class PlivoChannelTest extends \PHPUnit_Framework_TestCase
     protected $baseConfig = [
         'auth_id' => 'UNIT_TEST_AUTH_ID',
         'auth_token' => 'UNIT_TEST_AUTH_TOKEN',
-        'from_number' => '18885551111'
+        'from_number' => '18885551111',
     ];
 
     /**
@@ -45,7 +45,7 @@ class PlivoChannelTest extends \PHPUnit_Framework_TestCase
             'src' => $config['from_number'],
             'dst' => $this->notifiable->routeNotificationFor('plivo'),
             'text' => 'Content',
-            'url' => ''
+            'url' => '',
         ]);
 
         $notification = $this->notification(new PlivoMessage('Content'));
@@ -65,7 +65,7 @@ class PlivoChannelTest extends \PHPUnit_Framework_TestCase
             'src' => $config['from_number'],
             'dst' => $this->notifiable->routeNotificationFor('plivo'),
             'text' => 'Content',
-            'url' => 'https://defaultexample.com'
+            'url' => 'https://defaultexample.com',
         ]);
 
         $notification = $this->notification(new PlivoMessage('Content'));
@@ -85,7 +85,7 @@ class PlivoChannelTest extends \PHPUnit_Framework_TestCase
             'src' => $config['from_number'],
             'dst' => $this->notifiable->routeNotificationFor('plivo'),
             'text' => 'Content',
-            'url' => 'https://messagewebhook.com'
+            'url' => 'https://messagewebhook.com',
         ]);
 
         $notification = $this->notification(new PlivoMessage('Content', 'https://messagewebhook.com'));

--- a/tests/PlivoMessageTest.php
+++ b/tests/PlivoMessageTest.php
@@ -40,4 +40,12 @@ class PlivoMessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1234567890', $this->message->from);
     }
+
+    /** @test */
+    public function it_can_set_the_webhook()
+    {
+        $this->message->webhook('https://example.com');
+
+        $this->assertEquals('https://example.com', $this->message->webhook);
+    }
 }

--- a/tests/PlivoTest.php
+++ b/tests/PlivoTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NotificationChannels\Plivo\Test;
+
+use NotificationChannels\Plivo\Plivo;
+
+class PlivoTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_instantiate_from_config_without_webhook()
+    {
+        $config = [
+            'auth_id' => 'UNIT_TEST_AUTH_ID',
+            'auth_token' => 'UNIT_TEST_AUTH_ID',
+            'from_number' => '18885551111',
+        ];
+
+        $plivo = new Plivo($config);
+
+        $this->assertEquals('18885551111', $plivo->from());
+
+        $this->assertSame('', $plivo->webhook());
+    }
+
+    /** @test */
+    public function it_can_instantiate_from_config_with_webhook()
+    {
+        $config = [
+            'auth_id' => 'UNIT_TEST_AUTH_ID',
+            'auth_token' => 'UNIT_TEST_AUTH_ID',
+            'from_number' => '18885551111',
+            'webhook' => 'https://examplewebhook.com'
+        ];
+
+        $plivo = new Plivo($config);
+
+        $this->assertEquals('18885551111', $plivo->from());
+
+        $this->assertEquals('https://examplewebhook.com', $plivo->webhook());
+    }
+}

--- a/tests/PlivoTest.php
+++ b/tests/PlivoTest.php
@@ -29,7 +29,7 @@ class PlivoTest extends \PHPUnit_Framework_TestCase
             'auth_id' => 'UNIT_TEST_AUTH_ID',
             'auth_token' => 'UNIT_TEST_AUTH_ID',
             'from_number' => '18885551111',
-            'webhook' => 'https://examplewebhook.com'
+            'webhook' => 'https://examplewebhook.com',
         ];
 
         $plivo = new Plivo($config);


### PR DESCRIPTION
Plivo has support for reporting the status changes of an sms message via web hooks.
More info can be found [here.](https://www.plivo.com/docs/api/message)

This pull request provides support for this functionality simply by specifying a 'webhook' in the config file.